### PR TITLE
whz NDArray doc

### DIFF
--- a/docs/cvm/capi/index.rst
+++ b/docs/cvm/capi/index.rst
@@ -1,3 +1,4 @@
+.. _c-backend-api-label:
 
 C Backend API
 =============

--- a/docs/cvm/index.rst
+++ b/docs/cvm/index.rst
@@ -54,3 +54,11 @@ C++ API
   :maxdepth: 3
 
   All API <capi/index>
+
+Class Documentation
+===================
+
+.. toctree::
+  :maxdepth: 1
+
+  NDArray <ndarray>

--- a/docs/cvm/ndarray.rst
+++ b/docs/cvm/ndarray.rst
@@ -1,20 +1,29 @@
 NDArray
 =============
 
-This is the document of ``NDArray``, multi dimension array containing data, a
-core module in CVM Runtime. This core function is implemented with C++ and
-there are APIs for other languages.
+This is the document of ``NDArray``, multi-dimension array containing data, a
+core module in CVM Runtime. This part of documentation helps with understanding
+the design and APIs of ``NDArray`` and related classes or methods.
 
 Overview
 --------
+
+``NDArray``, as discussed above, is the multi-dimension array containing data.
+This class provides users with memory management and persistence. The core
+function is implemented with C++ and there are APIs for other languages.
+
+Memory Layout
+-------------
 
 Understanding the memory layout will help understanding the function.
 
 ``NDArray`` has a, and only has a, pointer to a ``Container`` class.
 
 The ``Container`` class is a wrapper for the core data structure ``DLTensor``,
-together with some other variables, providing useful features like reference
-count and lazy copy. The memory layout is as below: 
+containing a ``DLTensor`` instance instead of a pointer, together with some
+other variables, providing useful features like reference count and lazy copy.
+
+The memory layout is as below:
 ::
                  
   +-NDArray----+        +-Container--+
@@ -29,26 +38,58 @@ count and lazy copy. The memory layout is as below:
                         |    ...     |
                         +------------+
 
-This shows how the NDArray works.
+This graph shows the memory layout of NDArray.
 
 A ``DLTensor`` is a data structure that holds the data, running context, shape
-of the data and other informations. Considering that the ``DLTensor`` is still
+of the data and other information. Considering that the ``DLTensor`` is still
 very simple, it should be wrapped in a container class providing operations
 and optimizations like reference count and lazy copy, that's why ``Container``
-class is introduced.
+class is introduced -- to store other necessary data right after a ``DLTensor``.
 
 The memory management logic in C++ provides some convenient but tricky ways to
 initialize an ``NDArray`` or a ``DLTensor`` object. There's an interface called
 ``CVMArrayAlloc`` that creates a ``DLTensor`` and returns a pointer to it.
 However, **what the interface actually returned is a pointer to a** ``Container``.
-The memory layout princilpe of C++ promises ``DLTensor`` is right at the 
+The memory layout princilpe of C++ promises ``DLTensor`` is right at the
 beginning of a ``Container`` and thus, a ``Container*`` can be treated as a
 ``DLTensor*``.
 
-The benifit of such method is that memory memagement procedure is totally 
+The benifit of such method is that memory memagement procedure is totally
 transparent to API callers, which means all it can see is a ``DLTensor`` and all it
 need to do is call an API to get this tensor and call another API to destruct it.
 Destructing the tensor needs the data in its ``Container``.
 
-All in all, remember that **user can create a** ``DLTensor`` **only with**
-``CVMArrayAlloc`` **and must destruct it with calling** ``CVMArrayFree``
+All in all, remember that **users can only create a** ``DLTensor`` ** with**
+``CVMArrayAlloc`` **, must destruct it with calling** ``CVMArrayFree`` and should
+NEVER write into the memory after it.
+
+
+NDArray & API
+-------------
+
+CVMArrayAlloc
+~~~~~~~~~~~~~
+
+As mentioned above, this API creats a pointer to a ``DLTensor`` in users' view. What
+it actually returns, however, is a point to a ``Container`` and the content outside
+the ``DLTensor`` but inside the ``Container`` should never be modified.
+
+For detailed information, you can refer to ?????????
+
+CVMArrayFree
+~~~~~~~~~~~~
+
+If a ``DLTensor`` is created manually created by calling ``CVMArrayAlloc``, the user
+then must call ``CVMArrayFree`` to free the memory. Otherwise memory leakage may
+happen.
+
+
+NDArray & Model
+---------------
+
+In present CVM version, the most useful use case of NDArray is using it in a model.
+To use it in a model, persistence is necessary. ``CVMSaveParamsDict`` and
+``CVMLoadParamsDict`` do the persistence work, saving and loading a string-value
+dictionary.
+
+For detailed information, you can refer to ????????

--- a/docs/cvm/ndarray.rst
+++ b/docs/cvm/ndarray.rst
@@ -1,0 +1,54 @@
+NDArray
+=============
+
+This is the document of ``NDArray``, multi dimension array containing data, a
+core module in CVM Runtime. This core function is implemented with C++ and
+there are APIs for other languages.
+
+Overview
+--------
+
+Understanding the memory layout will help understanding the function.
+
+``NDArray`` has a, and only has a, pointer to a ``Container`` class.
+
+The ``Container`` class is a wrapper for the core data structure ``DLTensor``,
+together with some other variables, providing useful features like reference
+count and lazy copy. The memory layout is as below: 
+::
+                 
+  +-NDArray----+        +-Container--+
+  | Container*-|------->| +DLTensor+ |      +-----------+
+  +------------+        | | data*--|-|----->|  Memory   |
+                        | | ndim   | |      |           |
+                        | | context| |      |           |
+                        | |  ...   | |      +-----------+
+                        | +--------+ |
+                        |  ref_cnt   |
+                        |  type_code |
+                        |    ...     |
+                        +------------+
+
+This shows how the NDArray works.
+
+A ``DLTensor`` is a data structure that holds the data, running context, shape
+of the data and other informations. Considering that the ``DLTensor`` is still
+very simple, it should be wrapped in a container class providing operations
+and optimizations like reference count and lazy copy, that's why ``Container``
+class is introduced.
+
+The memory management logic in C++ provides some convenient but tricky ways to
+initialize an ``NDArray`` or a ``DLTensor`` object. There's an interface called
+``CVMArrayAlloc`` that creates a ``DLTensor`` and returns a pointer to it.
+However, **what the interface actually returned is a pointer to a** ``Container``.
+The memory layout princilpe of C++ promises ``DLTensor`` is right at the 
+beginning of a ``Container`` and thus, a ``Container*`` can be treated as a
+``DLTensor*``.
+
+The benifit of such method is that memory memagement procedure is totally 
+transparent to API callers, which means all it can see is a ``DLTensor`` and all it
+need to do is call an API to get this tensor and call another API to destruct it.
+Destructing the tensor needs the data in its ``Container``.
+
+All in all, remember that **user can create a** ``DLTensor`` **only with**
+``CVMArrayAlloc`` **and must destruct it with calling** ``CVMArrayFree``

--- a/docs/cvm/ndarray.rst
+++ b/docs/cvm/ndarray.rst
@@ -59,9 +59,9 @@ transparent to API callers, which means all it can see is a ``DLTensor`` and all
 need to do is call an API to get this tensor and call another API to destruct it.
 Destructing the tensor needs the data in its ``Container``.
 
-All in all, remember that **users can only create a** ``DLTensor`` ** with**
-``CVMArrayAlloc`` **, must destruct it with calling** ``CVMArrayFree`` and should
-NEVER write into the memory after it.
+All in all, remember that **users can only create a** ``DLTensor`` **with**
+``CVMArrayAlloc`` **, must destruct it with calling** ``CVMArrayFree`` **and should
+NEVER write into the memory after it.**
 
 
 NDArray & API
@@ -74,7 +74,7 @@ As mentioned above, this API creats a pointer to a ``DLTensor`` in users' view. 
 it actually returns, however, is a point to a ``Container`` and the content outside
 the ``DLTensor`` but inside the ``Container`` should never be modified.
 
-For detailed information, you can refer to ?????????
+For detailed information, you can refer to ``CVMArrayAlloc`` in :ref:`c-backend-api-label`.
 
 CVMArrayFree
 ~~~~~~~~~~~~
@@ -83,6 +83,7 @@ If a ``DLTensor`` is created manually created by calling ``CVMArrayAlloc``, the 
 then must call ``CVMArrayFree`` to free the memory. Otherwise memory leakage may
 happen.
 
+For detailed information, you can refer to ``CVMArrayFree`` in :ref:`c-backend-api-label`.
 
 NDArray & Model
 ---------------
@@ -92,4 +93,4 @@ To use it in a model, persistence is necessary. ``CVMSaveParamsDict`` and
 ``CVMLoadParamsDict`` do the persistence work, saving and loading a string-value
 dictionary.
 
-For detailed information, you can refer to ????????
+For detailed information, you can refer to :ref:`c-backend-api-label`.


### PR DESCRIPTION
A brief doc for `NDArray` for issue #69 
TODO: this doc refers to `CVMArrayAlloc`, `CVMArrayFree`, which are already generated, `CVMSaveParamsDict` and `CVMLoadParamsDict`, which are not done yet.

position of link seems to be not completely done yet.